### PR TITLE
Translate Chapter 2 routing narrative to Traditional Chinese

### DIFF
--- a/01-Part_One/Chapter_2-Routing-1ux_n8n3T4bYndOjs1DKW5ccpC802KISdy2IWnlvYbas.md
+++ b/01-Part_One/Chapter_2-Routing-1ux_n8n3T4bYndOjs1DKW5ccpC802KISdy2IWnlvYbas.md
@@ -1,58 +1,58 @@
-# Chapter 2: Routing
+# 第二章：路由(Routing)
 
-## Routing Pattern Overview
+## 路由模式(Routing Pattern)概覽
 
-While sequential processing via prompt chaining is a foundational technique for executing deterministic, linear workflows with language models, its applicability is limited in scenarios requiring adaptive responses. Real-world agentic systems must often arbitrate between multiple potential actions based on contingent factors, such as the state of the environment, user input, or the outcome of a preceding operation. This capacity for dynamic decision-making, which governs the flow of control to different specialized functions, tools, or sub-processes, is achieved through a mechanism known as routing.
+雖然透過提示鏈(prompt chaining)進行的順序處理是運行具決定性、線性工作流程的基礎技術，但在需要自適應反應的情境下，它的適用性有限。現實世界中的代理系統(agentic system)往往必須根據環境狀態、使用者輸入或前一個操作結果等偶發因素，在多個潛在行動之間仲裁。這種能夠動態決策、將流程導向不同專門功能、工具或子程序(sub-process)的能力，是透過稱為路由(routing)的機制實現。
 
-Routing introduces conditional logic into an agent's operational framework, enabling a shift from a fixed execution path to a model where the agent dynamically evaluates specific criteria to select from a set of possible subsequent actions. This allows for more flexible and context-aware system behavior.
+路由(routing)將條件邏輯(conditional logic)引入代理(agents)的操作框架，使系統從固定執行路徑轉向由代理動態評估特定條件，再從一系列可能的後續行動中作出選擇的模式。這種方式讓系統行為更加靈活並具備情境感知。
 
-For instance, an agent designed for customer inquiries, when equipped with a routing function, can first classify an incoming query to determine the user's intent. Based on this classification, it can then direct the query to a specialized agent for direct question-answering, a database retrieval tool for account information, or an escalation procedure for complex issues, rather than defaulting to a single, predetermined response pathway.  Therefore, a more sophisticated agent using routing could:
+例如，一個為客戶查詢而設計的代理，只要配備路由(routing)功能，就能先分類傳入問題以判斷使用者意圖。根據分類結果，它可以將查詢導向專門的直接答問代理、用於帳戶資訊的資料庫檢索工具，或處理複雜問題的升級程序，而不是預設走單一、預先決定的回應路徑。因此，一個使用路由(routing)的更複雜代理可以：
 
-1. Analyze the user's query.  
-2. **Route** the query based on its *intent*:  
-   * If the intent is "check order status", route to a sub-agent or tool chain that interacts with the order database.  
-   * If the intent is "product information", route to a sub-agent or chain that searches the product catalog.  
-   * If the intent is "technical support", route to a different chain that accesses troubleshooting guides or escalates to a human.  
-   * If the intent is unclear, route to a clarification sub-agent or prompt chain.
+1. 分析使用者的查詢。
+2. **根據意圖(intent)路由(route)** 查詢：
+   * 如果意圖是「查詢訂單狀態」，就路由至與訂單資料庫互動的子代理或工具鏈(tool chain)。
+   * 如果意圖是「產品資訊」，就路由至搜尋產品目錄的子代理或鏈(chain)。
+   * 如果意圖是「技術支援」，就路由至存取疑難排解指南或升級至真人的人員的另一條鏈(chain)。
+   * 如果意圖不明，就路由至澄清子代理或提示鏈(prompt chain)。
 
-The core component of the Routing pattern is a mechanism that performs the evaluation and directs the flow. This mechanism can be implemented in several ways:
+路由模式(Routing pattern)的核心組件是執行評估並引導流程的機制。這個機制可以透過多種方式實作：
 
-* **LLM-based Routing:** The language model itself can be prompted to analyze the input and output a specific identifier or instruction that indicates the next step or destination. For example, a prompt might ask the LLM to "Analyze the following user query and output only the category: 'Order Status', 'Product Info', 'Technical Support', or 'Other'." The agentic system then reads this output and directs the workflow accordingly.  
-* **Embedding-based Routing:** The input query can be converted into a vector embedding (see RAG, Chapter 14). This embedding is then compared to embeddings representing different routes or capabilities. The query is routed to the route whose embedding is most similar. This is useful for semantic routing, where the decision is based on the meaning of the input rather than just keywords.  
-* **Rule-based Routing:** This involves using predefined rules or logic (e.g., if-else statements, switch cases) based on keywords, patterns, or structured data extracted from the input. This can be faster and more deterministic than LLM-based routing, but is less flexible for handling nuanced or novel inputs.  
-* **Machine Learning Model-Based Routing**: it employs a discriminative model, such as a classifier, that has been specifically trained on a small corpus of labeled data to perform a routing task. While it shares conceptual similarities with embedding-based methods, its key characteristic is the supervised fine-tuning process, which adjusts the model's parameters to create a specialized routing function. This technique is distinct from LLM-based routing because the decision-making component is not a generative model executing a prompt at inference time. Instead, the routing logic is encoded within the fine-tuned model's learned weights. While LLMs may be used in a pre-processing step to generate synthetic data for augmenting the training set, they are not involved in the real-time routing decision itself.
+* **基於大型語言模型(LLM)的路由(LLM-based Routing)：** 語言模型(language model)本身可以透過提示(prompt)來分析輸入，並輸出指出下一步或目的地的特定識別碼或指令。例如，提示可以要求大型語言模型(LLM)「分析以下使用者查詢，並只輸出分類：'Order Status'、'Product Info'、'Technical Support' 或 'Other'。」代理系統會讀取這個輸出，並據此導引工作流程。
+* **基於嵌入(embedding)的路由(Embedding-based Routing)：** 輸入查詢可以轉換成向量嵌入(vector embedding)（詳見第14章的檢索增強生成(RAG)）。這個嵌入會與代表不同路徑或功能的嵌入進行比較，查詢會路由至嵌入最相似的路徑。這對於語意路由(semantic routing)很有用，因為決策是基於輸入的意義而不只是關鍵字。
+* **基於規則(rule-based)的路由(Rule-based Routing)：** 這涉及使用預先定義的規則或邏輯（例如 if-else 陳述、switch case），依據輸入中的關鍵字、模式或結構化資料進行判斷。這比基於大型語言模型(LLM)的路由更快速、更具決定性，但在處理細膩或新奇輸入時較缺乏彈性。
+* **基於機器學習模型(machine learning model)的路由(Machine Learning Model-Based Routing)：** 它採用在一小份標註資料上專門訓練的辨別模型(classifier)，以執行路由任務。儘管在概念上與基於嵌入的方法相似，其關鍵特徵是監督式微調(supervised fine-tuning)流程，會調整模型參數以建立專門的路由功能。這種技術不同於基於大型語言模型(LLM)的路由，因為決策元件不是在推理時執行提示的生成式模型(generative model)。相反地，路由邏輯被編碼在微調後模型的權重(weights)之中。大型語言模型(LLM)可能在前處理步驟中用來產生合成資料，以擴增訓練集，但並未參與即時的路由決策。
 
-Routing mechanisms can be implemented at multiple junctures within an agent's operational cycle. They can be applied at the outset to classify a primary task, at intermediate points within a processing chain to determine a subsequent action, or during a subroutine to select the most appropriate tool from a given set.
+路由機制可以在代理操作週期的多個節點實施。它們可以在一開始用於分類主要任務，在處理鏈(chain)的中間點決定後續行動，或於子程序(subroutine)中自一組工具(tool)選出最合適的工具。
 
-Computational frameworks such as LangChain, LangGraph, and Google's Agent Developer Kit (ADK) provide explicit constructs for defining and managing such conditional logic. With its state-based graph architecture, LangGraph is particularly well-suited for complex routing scenarios where decisions are contingent upon the accumulated state of the entire system. Similarly, Google's ADK provides foundational components for structuring an agent's capabilities and interaction models, which serve as the basis for implementing routing logic. Within the execution environments provided by these frameworks, developers define the possible operational paths and the functions or model-based evaluations that dictate the transitions between nodes in the computational graph.
+像 LangChain、LangGraph 以及 Google 的代理開發套件(Agent Developer Kit，ADK)等運算框架，提供明確的結構來定義與管理此類條件邏輯(conditional logic)。LangGraph 透過其基於狀態(state-based)的圖形架構(graph architecture)，特別適合處理決策依賴整個系統累積狀態的複雜路由情境。同樣地，Google 的 ADK 提供用來建構代理能力與互動模型的基礎元件，作為實作路由邏輯的基礎。在這些框架的執行環境中，開發者會定義可能的操作路徑，以及決定在計算圖(computational graph)節點之間轉換的功能或基於模型的評估。
 
-The implementation of routing enables a system to move beyond deterministic sequential processing. It facilitates the development of more adaptive execution flows that can respond dynamically and appropriately to a wider range of inputs and state changes.
+路由(routing)的實作讓系統得以超越決定性的順序處理。它促進更具適應性的執行流程開發，讓系統能動態且適切地回應更廣泛的輸入與狀態變化。
 
-## Practical Applications & Use Cases
+## 實務應用與使用情境(Practical Applications & Use Cases)
 
-The routing pattern is a critical control mechanism in the design of adaptive agentic systems, enabling them to dynamically alter their execution path in response to variable inputs and internal states. Its utility spans multiple domains by providing a necessary layer of conditional logic.
+路由模式(Routing pattern)是設計自適應代理系統的關鍵控制機制，使系統能根據多變的輸入和內部狀態動態調整執行路徑。透過提供必要的條件邏輯層，它的效用遍及多個領域。
 
-In human-computer interaction, such as with virtual assistants or AI-driven tutors, routing is employed to interpret user intent. An initial analysis of a natural language query determines the most appropriate subsequent action, whether it is invoking a specific information retrieval tool, escalating to a human operator, or selecting the next module in a curriculum based on user performance. This allows the system to move beyond linear dialogue flows and respond contextually.
+在人機互動(human-computer interaction)領域，例如虛擬助理或人工智慧教學系統中，路由(routing)被用來詮釋使用者意圖。對自然語言查詢的初步分析會決定最適合的下一步行動，無論是呼叫特定的資訊檢索工具、升級至真人服務人員，或根據使用者表現選擇課程中的下一個模組。這讓系統能超越線性的對話流程，做出具情境的回應。
 
-Within automated data and document processing pipelines, routing serves as a classification and distribution function. Incoming data, such as emails, support tickets, or API payloads, is analyzed based on content, metadata, or format. The system then directs each item to a corresponding workflow, such as a sales lead ingestion process, a specific data transformation function for JSON or CSV formats, or an urgent issue escalation path.
+在自動化資料與文件處理流程中，路由(routing)扮演分類與分發功能。傳入資料（例如電子郵件、支援單或 API 載荷）會根據內容、中繼資料(metadata)或格式進行分析。系統會將每個項目導向相應的工作流程，例如銷售機會匯入流程、針對 JSON 或 CSV 格式的特定資料轉換功能，或緊急議題的升級通道。
 
-In complex systems involving multiple specialized tools or agents, routing acts as a high-level dispatcher. A research system composed of distinct agents for searching, summarizing, and analyzing information would use a router to assign tasks to the most suitable agent based on the current objective. Similarly, an AI coding assistant uses routing to identify the programming language and user's intent—to debug, explain, or translate—before passing a code snippet to the correct specialized tool.
+在涉及多個專門工具或代理的複雜系統中，路由(routing)扮演高階調度器(dispatcher)。一個包含搜尋、摘要及分析資訊的獨立代理的研究系統，會使用路由器(router)根據當前目標，將任務指派給最合適的代理。同樣地，人工智慧編碼助理會利用路由(routing)，先辨識程式語言與使用者意圖（除錯、說明或翻譯），再把程式碼片段交給正確的專門工具。
 
-Ultimately, routing provides the capacity for logical arbitration that is essential for creating functionally diverse and context-aware systems. It transforms an agent from a static executor of pre-defined sequences into a dynamic system that can make decisions about the most effective method for accomplishing a task under changing conditions.
+最終，路由(routing)提供了邏輯仲裁(logical arbitration)的能力，是建立功能多樣且具情境感知系統的關鍵。它將代理從執行預先定義序列的靜態角色，轉變為在變動情況下能決定最有效完成任務方式的動態系統。
 
-## Hands-On Code Example (LangChain)
+## 實作範例：LangChain(Hands-On Code Example (LangChain))
 
-Implementing routing in code involves defining the possible paths and the logic that decides which path to take. Frameworks like LangChain and LangGraph provide specific components and structures for this. LangGraph's state-based graph structure is particularly intuitive for visualizing and implementing routing logic.
+在程式中實作路由(routing)涉及定義可能路徑以及決定該走哪條路的邏輯。像 LangChain 與 LangGraph 等框架提供針對此用途的特定元件與結構。LangGraph 的狀態式圖形結構特別直觀，適合用於視覺化與實作路由邏輯。
 
-This code demonstrates a simple agent-like system using LangChain and Google's Generative AI. It sets up a "coordinator" that routes user requests to different simulated "sub-agent" handlers based on the request's intent (booking, information, or unclear). The system uses a language model to classify the request and then delegates it to the appropriate handler function, simulating a basic delegation pattern often seen in multi-agent architectures.
+以下程式碼示範了一個使用 LangChain 與 Google 生成式人工智慧(Generative AI)的簡單代理式系統。它建立一個「協調者(coordinator)」，依據請求意圖（訂位、資訊或不清楚），將使用者請求路由至不同的模擬「子代理(sub-agent)」處理器。系統利用語言模型(language model)分類請求，然後委派至適當的處理函式，模擬多代理架構中常見的基本委派模式。
 
-First, ensure you have the necessary libraries installed:
+首先，請確保安裝必要的程式庫：
 
 ```bash
 pip install langchain langgraph google-cloud-aiplatform langchain-google-genai google-adk deprecated pydantic
 ```
 
-You will also need to set up your environment with your API key for the language model you choose (e.g., OpenAI, Google Gemini, Anthropic).
+你還需要為所選的語言模型設定環境中的 API 金鑰（例如 OpenAI、Google Gemini、Anthropic）。
 
 ```python
 # Copyright (c) 2025 Marco Fago
@@ -175,17 +175,17 @@ if __name__ == "__main__":
     main()
 ```
 
-As mentioned, this Python code constructs a simple agent-like system using the LangChain library and Google's Generative AI model, specifically gemini-2.5-flash. In detail, It defines three simulated sub-agent handlers: `booking_handler`, `info_handler`, and `unclear_handler`, each designed to process specific types of requests.
+如前所述，這段 Python 程式碼使用 LangChain 函式庫與 Google 的生成式人工智慧模型(Generative AI model)，特別是 gemini-2.5-flash，建構了一個簡單的代理式系統。它定義三個模擬子代理(sub-agent)處理器：`booking_handler`、`info_handler` 與 `unclear_handler`，各自用於處理特定類型的請求。
 
-A core component is the `coordinator_router_chain`, which utilizes a ChatPromptTemplate to instruct the language model to categorize incoming user requests into one of three categories: `booker`, `info`, or `unclear`. The output of this router chain is then used by a RunnableBranch to delegate the original request to the corresponding handler function. The RunnableBranch checks the decision from the language model and directs the request data to either the `booking_handler`, `info_handler`, or `unclear_handler`. The `coordinator_agent` combines these components, first routing the request for a decision and then passing the request to the chosen handler. The final output is extracted from the handler's response.
+核心組件是 `coordinator_router_chain`，它利用 ChatPromptTemplate 指示語言模型(language model)將傳入使用者請求分類為 `booker`、`info` 或 `unclear`。這個路由鏈(router chain)的輸出接著由 RunnableBranch 使用，將原始請求委派至相應的處理函式。RunnableBranch 會檢查語言模型(language model)的決策，並將請求資料導向 `booking_handler`、`info_handler` 或 `unclear_handler`。`coordinator_agent` 將這些元件組合起來，先將請求送往路由決策，再把請求交給選定的處理器，最後擷取處理器回應作為輸出。
 
-The main function demonstrates the system's usage with three example requests, showcasing how different inputs are routed and processed by the simulated agents. Error handling for language model initialization is included to ensure robustness. The code structure mimics a basic multi-agent framework where a central coordinator delegates tasks to specialized agents based on intent.
+主函式(main function)透過三個範例請求示範系統的運作，展示不同輸入如何被路由並由模擬代理處理。同時也加入語言模型(language model)初始化的錯誤處理，以確保穩健性。整體程式結構模擬了一個基本的多代理框架，其中中央協調者將任務委派給根據意圖(intent)專門化的代理。
 
-## Hands-On Code Example (Google ADK)
+## 實作範例：Google ADK(Hands-On Code Example (Google ADK))
 
-The Agent Development Kit (ADK) is a framework for engineering agentic systems, providing a structured environment for defining an agent's capabilities and behaviours. In contrast to architectures based on explicit computational graphs, routing within the ADK paradigm is typically implemented by defining a discrete set of "tools" that represent the agent's functions. The selection of the appropriate tool in response to a user query is managed by the framework's internal logic, which leverages an underlying model to match user intent to the correct functional handler.
+代理開發套件(Agent Development Kit，ADK)是一個用於工程化代理系統的框架，提供結構化環境以定義代理的能力與行為。相較於基於明確計算圖(computational graph)的架構，在 ADK 範式中，路由(routing)通常透過定義代表代理功能的一組「工具(tools)」來實作。框架的內部邏輯會管理針對使用者查詢選擇適當工具的過程，並透過底層模型(model)將使用者意圖對應至正確的功能處理器(handler)。
 
-This Python code demonstrates an example of an Agent Development Kit (ADK) application using Google's ADK library. It sets up a "Coordinator" agent that routes user requests to specialized sub-agents ("Booker" for bookings and "Info" for general information) based on defined instructions. The sub-agents then use specific tools to simulate handling the requests, showcasing a basic delegation pattern within an agent system
+以下 Python 程式碼示範如何使用 Google 的 ADK 函式庫建立代理開發套件(ADK)應用。它設定一個「協調者(Coordinator)」代理，依據定義的指示將使用者請求路由至專門子代理(`"Booker"` 用於訂位，`"Info"` 用於一般資訊)。子代理再使用特定工具(tools)模擬處理請求，展示代理系統內的基本委派模式。
 
 ```python
 # Copyright (c) 2025 Marco Fago
@@ -346,42 +346,42 @@ if __name__ == "__main__":
     await main()
 ```
 
-This script consists of a main Coordinator agent and two specialized `sub_agents`: Booker and Info. Each specialized agent is equipped with a FunctionTool that wraps a Python function simulating an action. The `booking_handler` function simulates handling flight and hotel bookings, while the `info_handler` function simulates retrieving general information. The `unclear_handler` is included as a fallback for requests the coordinator cannot delegate, although the current coordinator logic doesn't explicitly use it for delegation failure in the main `run_coordinator` function.
+這個腳本由一個主要的協調者(Coordinator)代理和兩個專門的 `sub_agents`（Booker 與 Info）組成。每個專門代理都配置一個包裝 Python 函式、模擬操作的 FunctionTool。`booking_handler` 函式模擬處理航班與飯店訂位，而 `info_handler` 函式模擬擷取一般資訊。`unclear_handler` 則作為協調者無法委派時的後備方案，雖然目前協調者邏輯在 `run_coordinator` 主流程中沒有明確使用它處理委派失敗。
 
-The Coordinator agent's primary role, as defined in its instruction, is to analyze incoming user messages and delegate them to either the Booker or Info agent. This delegation is handled automatically by the ADK's Auto-Flow mechanism because the Coordinator has `sub_agents` defined. The `run_coordinator` function sets up an InMemoryRunner, creates a user and session ID, and then uses the runner to process the user's request through the coordinator agent. The runner.run method processes the request and yields events, and the code extracts the final response text from the event.content.
+協調者(Coordinator)代理的主要職責，如其指示(instruction)所述，是分析傳入的使用者訊息並將其委派給 Booker 或 Info 代理。由於協調者定義了 `sub_agents`，ADK 的 Auto-Flow 機制會自動處理這項委派。`run_coordinator` 函式會建立 InMemoryRunner，創建使用者與工作階段(session)識別碼，然後使用 runner 處理協調者代理的使用者請求。`runner.run` 方法會處理請求並產生事件(event)，程式會從 event.content 中擷取最終回應文字。
 
-The main function demonstrates the system's usage by running the coordinator with different requests, showcasing how it delegates booking requests to the Booker and information requests to the Info agent.
+主函式(main function)透過不同的請求示範系統運作，展示如何把訂位請求委派給 Booker，以及將資訊請求委派給 Info 代理。
 
-## At a Glance
+## 快速總結(At a Glance)
 
-**What**: Agentic systems must often respond to a wide variety of inputs and situations that cannot be handled by a single, linear process. A simple sequential workflow lacks the ability to make decisions based on context. Without a mechanism to choose the correct tool or sub-process for a specific task, the system remains rigid and non-adaptive. This limitation makes it difficult to build sophisticated applications that can manage the complexity and variability of real-world user requests.
+**重點是什麼(What)：** 代理系統(agentic system)經常必須回應無法由單一線性流程處理的各式輸入與情境。單純的順序工作流程缺乏依情境進行決策的能力。若沒有挑選特定任務所需工具或子程序(sub-process)的機制，系統就會維持僵化且缺乏適應性。這種限制使得難以建立能處理現實世界使用者請求複雜度與多變性的進階應用。
 
-**Why:** The Routing pattern provides a standardized solution by introducing conditional logic into an agent's operational framework. It enables the system to first analyze an incoming query to determine its intent or nature. Based on this analysis, the agent dynamically directs the flow of control to the most appropriate specialized tool, function, or sub-agent. This decision can be driven by various methods, including prompting LLMs, applying predefined rules, or using embedding-based semantic similarity. Ultimately, routing transforms a static, predetermined execution path into a flexible and context-aware workflow capable of selecting the best possible action.
+**為什麼(Why)：** 路由模式(Routing pattern)透過在代理操作框架中引入條件邏輯(conditional logic)，提供標準化解方。系統會先分析傳入查詢以判斷其意圖(intent)或本質，並根據分析結果動態將控制流程導向最適合的專門工具、功能或子代理。這項決策可以由提示大型語言模型(LLM)、套用預先定義的規則，或使用基於嵌入的語意相似度(semantic similarity)來驅動。最終，路由(routing)將靜態、預先決定的執行路徑，轉化為能夠情境感知且可選擇最佳行動的彈性工作流程。
 
-**Rule of Thumb:** Use the Routing pattern when an agent must decide between multiple distinct workflows, tools, or sub-agents based on the user's input or the current state. It is essential for applications that need to triage or classify incoming requests to handle different types of tasks, such as a customer support bot distinguishing between sales inquiries, technical support, and account management questions.
+**經驗法則(Rule of Thumb)：** 當代理需要依據使用者輸入或當前狀態，在多個截然不同的工作流程、工具或子代理之間做出選擇時，就應使用路由模式(Routing pattern)。它對必須分流或分類傳入請求以處理不同任務類型的應用至關重要，例如客服機器人區分銷售詢問、技術支援與帳戶管理問題。
 
-**Visual Summary:**
+**視覺摘要(Visual Summary)：**
 
 ![Router Pattern, using LLM as a Router](../assets/Router_Pattern_Using_LLM_as_a_Router.png)
 
-Fig.1: Router pattern, using an LLM as a Router
+圖1：使用大型語言模型(LLM)作為路由器(router)的路由模式(Router pattern)
 
-## Key Takeaways
+## 重要重點(Key Takeaways)
 
-* Routing enables agents to make dynamic decisions about the next step in a workflow based on conditions.  
-* It allows agents to handle diverse inputs and adapt their behavior, moving beyond linear execution.  
-* Routing logic can be implemented using LLMs, rule-based systems, or embedding similarity.  
-* Frameworks like LangGraph and Google ADK provide structured ways to define and manage routing within agent workflows, albeit with different architectural approaches.
+* 路由(routing)讓代理能根據條件為工作流程的下一步做動態決策。
+* 它讓代理能處理多樣輸入並調整行為，進而超越線性執行。
+* 路由邏輯可以使用大型語言模型(LLM)、基於規則的系統或嵌入相似度(embedding similarity)來實作。
+* LangGraph 與 Google ADK 等框架提供結構化方式，在代理工作流程中定義與管理路由(routing)，雖然採用不同的架構方法。
 
-## Conclusion
+## 結論(Conclusion)
 
-The Routing pattern is a critical step in building truly dynamic and responsive agentic systems. By implementing routing, we move beyond simple, linear execution flows and empower our agents to make intelligent decisions about how to process information, respond to user input, and utilize available tools or sub-agents.
+路由模式(Routing pattern)是在打造真正動態且具回應能力的代理系統時的關鍵一步。透過實作路由(routing)，我們得以超越簡單的線性執行流程，並賦予代理智慧決策能力，判斷如何處理資訊、回應使用者輸入，以及善用可用工具或子代理。
 
-We've seen how routing can be applied in various domains, from customer service chatbots to complex data processing pipelines. The ability to analyze input and conditionally direct the workflow is fundamental to creating agents that can handle the inherent variability of real-world tasks.
+我們已看到路由(routing)如何應用於不同領域，從客服聊天機器人到複雜的資料處理管線。分析輸入並有條件地導引工作流程，是建立能處理現實世界任務變異性的代理的基礎。
 
-The code examples using LangChain and Google ADK demonstrate two different, yet effective, approaches to implementing routing. LangGraph's graph-based structure provides a visual and explicit way to define states and transitions, making it ideal for complex, multi-step workflows with intricate routing logic. Google ADK, on the other hand, often focuses on defining distinct capabilities (Tools) and relies on the framework's ability to route user requests to the appropriate tool handler, which can be simpler for agents with a well-defined set of discrete actions.
+使用 LangChain 與 Google ADK 的程式碼示例，展示了兩種不同但同樣有效的路由實作方法。LangGraph 的圖形化結構提供視覺化且明確的方式來定義狀態與轉換，特別適合包含複雜路由邏輯的多步驟工作流程。相對地，Google ADK 常著重於定義獨立能力（工具），並仰賴框架將使用者請求路由至適當的工具處理器(handler)，這對具備明確離散行動集的代理而言較為簡潔。
 
-Mastering the Routing pattern is essential for building agents that can intelligently navigate different scenarios and provide tailored responses or actions based on context. It's a key component in creating versatile and robust agentic applications.
+精通路由模式(Routing pattern)是建立能聰明應對不同情境、並依據脈絡提供量身回應或行動的代理的關鍵。它是打造多才多藝且穩健代理應用的重要組成。
 
 ## References
 


### PR DESCRIPTION
## Summary
- translate Chapter 2: Routing into Traditional Chinese (Hong Kong) while retaining key technical terminology in parentheses
- keep the references section unchanged per instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62137dbbc832aa39893b6e89d8dba