### PR TITLE
Fix Context Engineering image reference in Chapter 1

### DIFF
--- a/01-Part_One/Chapter_1-Prompt_Chaining-1flxKGrbnF2g8yh3F-oVD5Xx7ZumId56HbFpIiPdkqLI.md
+++ b/01-Part_One/Chapter_1-Prompt_Chaining-1flxKGrbnF2g8yh3F-oVD5Xx7ZumId56HbFpIiPdkqLI.md
@@ -207,7 +207,7 @@ print(final_result)
 
 脈絡工程(Context Engineering)（見圖1）是指在語彙生成(token generation)之前，為AI模型設計、建構與提供完整資訊環境(informational environment)的系統化學科(discipline)。此方法認為，模型輸出的品質較少取決於模型架構(architecture)，而更依賴提供的脈絡(context)是否充足。
 
-![Context Engineering](../assets/context_engineering.png)
+![Context Engineering](../assets/Context_Engineering.png)
 
 圖1：脈絡工程(Context Engineering)是一門為AI建構豐富且全面資訊環境的學科，該脈絡的品質是成就進階代理式(agentic)效能的主要因素。
 


### PR DESCRIPTION
## Summary
- point the Chapter 1 Context Engineering illustration to the correctly capitalized asset file so the image renders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d625d849f0832abdc2a95cf7fb7c3d